### PR TITLE
Add cuda-samples

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -24,9 +24,15 @@ description: |
     Dump information about the available Vulkan setup.
   - vkcube (Apache-2.0):
     Test the Vulkan setup.
+  - bandwidthTest (MIT):
+    A sample NVIDIA CUDA application can be used to confirm CUDA operational status.
+    (needs nvidia-core22)
+  - deviceQuery (MIT):
+    Query NVIDIA CUDA hardware configuration. (needs nvidia-core22)
 
   This snap uses the graphics-core22 interface to gain support graphics hardware.
   It can be used to verify custom graphics-core22 provider implementations.
+  The CUDA specific apps require NVIDIA capable provider, such as nvidia-core22.
 
   See https://mir-server.io/docs/the-graphics-core22-snap-interface) for more
   information.
@@ -48,6 +54,20 @@ plugs:
     default-provider: mesa-core22
 
 apps:
+  bandwidthTest:
+    plugs:
+      - opengl
+    command-chain:
+      - bin/graphics-core22-wrapper
+    command: usr/bin/bandwidthTest
+
+  deviceQuery:
+    plugs:
+      - opengl
+    command-chain:
+      - bin/graphics-core22-wrapper
+    command: usr/bin/deviceQuery
+
   drm-info:
     plugs:
       - opengl
@@ -133,6 +153,38 @@ parts:
     stage-packages:
       - inotify-tools
 
+  cuda-samples:
+    source: https://github.com/NVIDIA/cuda-samples
+    source-tag: v11.5
+    source-type: git
+    source-depth: 1
+    plugin: nil
+    build-packages:
+      - build-essential
+      - on amd64:
+        - libnvidia-compute-515-server
+        - nvidia-cuda-toolkit
+      - on arm64:
+        - libnvidia-compute-515-server
+        - nvidia-cuda-toolkit
+    override-build: |
+      case $CRAFT_TARGET_ARCH in
+      amd64|arm64)
+      make -C Samples/bandwidthTest CUDA_PATH=/usr/lib/nvidia-cuda-toolkit
+      make -C Samples/deviceQuery CUDA_PATH=/usr/lib/nvidia-cuda-toolkit
+      mkdir -p $SNAPCRAFT_PART_INSTALL/usr/bin/
+      cp bin/*/linux/release/* $SNAPCRAFT_PART_INSTALL/usr/bin/
+      ;;
+      *)
+      mkdir -p $SNAPCRAFT_PART_INSTALL/usr/bin/
+      cp /bin/false $SNAPCRAFT_PART_INSTALL/usr/bin/bandwidthTest
+      cp /bin/false $SNAPCRAFT_PART_INSTALL/usr/bin/deviceQuery
+      ;;
+      esac
+    stage:
+      - usr/bin/bandwidthTest
+      - usr/bin/deviceQuery
+
   drm-info:
     plugin: nil
     stage-packages:
@@ -173,6 +225,7 @@ parts:
 
   graphics-core22:
     after:
+      - cuda-samples
       - drm-info
       - eglinfo
       - glmark2


### PR DESCRIPTION
trying to add cuda-samples, and questioning if this is interesting or not......

.... given that it seems to be arch restricted to amd64|arm64 and i'm failing to figure out how to make arch-specific only parts/apps.

Note that on unsupported arches the two new apps are just bin/false, let me know if that's ok, or if you want a wrapper that explains things.