### PR TITLE
fix: Bump cuda samples to 12.5

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -157,7 +157,7 @@ parts:
 
   cuda-samples:
     source: https://github.com/NVIDIA/cuda-samples
-    source-tag: v11.5
+    source-tag: v12.5
     source-type: git
     source-depth: 1
     plugin: nil
@@ -173,8 +173,8 @@ parts:
       mkdir -p ${CRAFT_PART_INSTALL}/usr/bin/
       case ${CRAFT_ARCH_BUILD_FOR} in
       amd64|arm64)
-        make -C Samples/bandwidthTest CUDA_PATH=/usr/lib/nvidia-cuda-toolkit
-        make -C Samples/deviceQuery CUDA_PATH=/usr/lib/nvidia-cuda-toolkit
+        make -C Samples/1_Utilities/bandwidthTest CUDA_PATH=/usr/lib/nvidia-cuda-toolkit
+        make -C ./Samples/1_Utilities/deviceQuery CUDA_PATH=/usr/lib/nvidia-cuda-toolkit
         mkdir -p ${CRAFT_PART_INSTALL}/usr/bin/
         cp bin/*/linux/release/deviceQuery bin/*/linux/release/bandwidthTest ${CRAFT_PART_INSTALL}/usr/bin/
       ;;


### PR DESCRIPTION
Noble ships with nvidia-cuda-toolkit 12, which no long supports <cc5.0 cuda-samples 11.x has build targets for <cc5.0, as it matches cuda version support